### PR TITLE
Removed duplicate field guest_os_type

### DIFF
--- a/debian-osint.json
+++ b/debian-osint.json
@@ -24,7 +24,6 @@
                 "<enter><wait>"
             ],
             "boot_wait": "5s",
-            "guest_os_type": "Debian_64",
             "iso_url": "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-{{user `debian_version`}}-amd64-xfce-CD-1.iso",
             "iso_checksum": "745172d8ba09f054335cc738409aede5c5f3463ae39df0a008eb41ceeba44b5c",
             "iso_checksum_type": "sha256",


### PR DESCRIPTION
To solve error:

❯ packer build debian-osint.json
Failed to parse template: template has duplicate field: guest_os_type

==> Builds finished but no artifacts were created.